### PR TITLE
Added generation of typed swagger responses based on CMS content types

### DIFF
--- a/src/UmbracoDemo.CMS/Custom/Swagger/DeliveryApiContentTypesSchemaFilter.cs
+++ b/src/UmbracoDemo.CMS/Custom/Swagger/DeliveryApiContentTypesSchemaFilter.cs
@@ -1,0 +1,222 @@
+﻿using System.Reflection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Umbraco.Cms.Api.Common.OpenApi;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+
+namespace UmbracoDemo.CMS.Custom.Swagger
+{
+    public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter
+    {
+        private readonly IOptions<SwaggerGenOptions> _swaggerGenOptions;
+        private readonly IContentTypeService _contentTypeService;
+        private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
+        private readonly ISchemaIdSelector _schemaIdSelector;
+        private readonly IShortStringHelper _shortStringHelper;
+
+        public DeliveryApiContentTypesSchemaFilter(IOptions<SwaggerGenOptions> swaggerGenOptions, IContentTypeService contentTypeService, IPublishedContentTypeFactory publishedContentTypeFactory, ISchemaIdSelector schemaIdSelector, IShortStringHelper shortStringHelper)
+        {
+            _swaggerGenOptions = swaggerGenOptions;
+            _contentTypeService = contentTypeService;
+            _publishedContentTypeFactory = publishedContentTypeFactory;
+            _schemaIdSelector = schemaIdSelector;
+            _shortStringHelper = shortStringHelper;
+        }
+
+        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        {
+            FixEnums(schema, context);
+
+            // Orval/Swashbuckle compatible, NOT supported by NSwag
+            bool useOneOfForPolymorphism = _swaggerGenOptions.Value.SchemaGeneratorOptions.UseOneOfForPolymorphism;
+
+            if (!useOneOfForPolymorphism && !_swaggerGenOptions.Value.SchemaGeneratorOptions.UseAllOfForInheritance)
+            {
+                return;
+            }
+
+            if (typeof(IApiElement) == context.Type)
+            {
+                HandleIApiElement(schema, context, useOneOfForPolymorphism);
+                return;
+            }
+
+            if (typeof(IApiContentResponse) == context.Type)
+            {
+                HandleIApiContentResponse(schema, context, useOneOfForPolymorphism);
+                return;
+            }
+        }
+
+        private void HandleIApiElement(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
+        {
+            OpenApiSchema? originalSchema = null;
+            if (useOneOfForPolymorphism)
+            {
+                // Swashbuckle doesn't allow us to return an inline schema
+                // So we instead clone the current schema as IApiElementBase and update the current schema to be OneOf
+
+                originalSchema = schema;
+                schema = new OpenApiSchema(originalSchema);
+
+                context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiElement>(true), schema);
+
+                ClearSchema(originalSchema);
+            }
+
+            schema.Discriminator = new OpenApiDiscriminator
+            {
+                PropertyName = "contentType"
+            };
+
+            foreach (IContentType contentType in _contentTypeService.GetAll())
+            {
+                IPublishedContentType publishedContentType = _publishedContentTypeFactory.CreateContentType(contentType);
+
+                var contentTypeSchema = context.SchemaRepository.AddDefinition(
+                    $"{GetContentTypeSchemaId(contentType)}ContentModel",
+                    new OpenApiSchema
+                    {
+                        Type = "object",
+                        AllOf = { new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiElement>(useOneOfForPolymorphism) } } },
+                        AdditionalPropertiesAllowed = false,
+                        Properties =
+                        {
+                                ["properties"] = context.SchemaRepository.AddDefinition(
+                                    $"{GetContentTypeSchemaId(contentType)}PropertiesModel",
+                                    new OpenApiSchema
+                                    {
+                                        Type = "object",
+                                        AdditionalPropertiesAllowed = true,
+                                        AllOf = contentType.ContentTypeComposition.Select(c => new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(c)}PropertiesModel" } }).ToList(),
+                                        Properties = publishedContentType.PropertyTypes
+                                            .Where(p => contentType.PropertyTypes.Any(x => x.Alias == p.Alias)) // Filter out composition properties
+                                            .ToDictionary(
+                                                p => p.Alias,
+                                                p => context.SchemaGenerator.GenerateSchema(GetPropertyType(p), context.SchemaRepository)
+                                            )
+                                    }
+                                )
+                        }
+                    }
+                );
+
+                schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
+                originalSchema?.OneOf.Add(contentTypeSchema);
+            }
+        }
+
+        private void HandleIApiContentResponse(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
+        {
+            // Ensure IApiElement is generated if not already
+            context.SchemaGenerator.GenerateSchema(typeof(IApiElement), context.SchemaRepository);
+
+            OpenApiSchema? originalSchema = null;
+            if (useOneOfForPolymorphism)
+            {
+                originalSchema = schema;
+                schema = new OpenApiSchema(originalSchema);
+                context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiContentResponse>(true), schema);
+
+                ClearSchema(originalSchema);
+            }
+
+            schema.AllOf.Add(new OpenApiSchema
+            {
+                Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiElement>(useOneOfForPolymorphism) }
+            });
+            schema.Discriminator = new OpenApiDiscriminator
+            {
+                PropertyName = "contentType"
+            };
+
+            foreach (IContentType contentType in _contentTypeService.GetAll().Where(c => !c.IsElement))
+            {
+                var contentTypeSchema = context.SchemaRepository.AddDefinition(
+                    $"{GetContentTypeSchemaId(contentType)}ContentResponseModel",
+                    new OpenApiSchema
+                    {
+                        Type = "object",
+                        AdditionalPropertiesAllowed = false,
+                        AllOf =
+                        {
+                            new OpenApiSchema
+                            {
+                                Reference = new OpenApiReference
+                                {
+                                    Type = ReferenceType.Schema,
+                                    Id = GetTypeSchemaId<IApiContentResponse>(useOneOfForPolymorphism)
+                                }
+                            },
+                            new OpenApiSchema
+                            {
+                                Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(contentType)}ContentModel" }
+                            }
+                        }
+                    }
+                );
+
+                schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
+                originalSchema?.OneOf.Add(contentTypeSchema);
+            }
+        }
+
+        private string GetContentTypeSchemaId(IContentTypeBase contentType)
+        {
+            // This is what ModelsBuilder currently also uses
+            return contentType.Alias.ToCleanString(_shortStringHelper, CleanStringType.ConvertCase | CleanStringType.PascalCase);
+        }
+
+        private string GetTypeSchemaId<T>(bool baseSuffix)
+        {
+            return _schemaIdSelector.SchemaId(typeof(T)) + (baseSuffix ? "Base" : null);
+        }
+
+        private void ClearSchema(OpenApiSchema schema)
+        {
+            schema.AllOf.Clear();
+            schema.OneOf.Clear();
+            schema.AnyOf.Clear();
+            schema.Required.Clear();
+            schema.Properties.Clear();
+            schema.AdditionalProperties = null;
+            schema.Discriminator = null;
+        }
+
+        // HACK: The DeliveryApi property value type is currently not exposed by Umbraco
+        private static readonly FieldInfo? ConverterField = typeof(PublishedPropertyType).GetField("_converter", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+        private static Type GetPropertyType(IPublishedPropertyType publishedPropertyType)
+        {
+            Type modelClrType = publishedPropertyType.ModelClrType;
+
+            switch (ConverterField?.GetValue(publishedPropertyType))
+            {
+                case BlockListPropertyValueConverter:
+                    // HACK: Needed due to umbraco returning the wrong type
+                    // https://github.com/umbraco/Umbraco-CMS/pull/14728
+                    return typeof(ApiBlockListModel);
+                case IDeliveryApiPropertyValueConverter propertyValueConverter:
+                    return propertyValueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType);
+                default:
+                    return modelClrType;
+            }
+        }
+
+        // HACK: Needed because Umbraco generates invalid enum schemas
+        // https://github.com/umbraco/Umbraco-CMS/pull/14727
+        private static void FixEnums(OpenApiSchema schema, SchemaFilterContext context)
+        {
+            if (!context.Type.IsEnum) return;
+
+            schema.Type = "string";
+            schema.Format = null;
+        }
+    }
+}

--- a/src/UmbracoDemo.CMS/Custom/Swagger/DeliveryApiContentTypesSchemaFilter.cs
+++ b/src/UmbracoDemo.CMS/Custom/Swagger/DeliveryApiContentTypesSchemaFilter.cs
@@ -1,7 +1,7 @@
-﻿using System.Reflection;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Reflection;
 using Umbraco.Cms.Api.Common.OpenApi;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.DeliveryApi;
@@ -11,217 +11,277 @@ using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
-namespace UmbracoDemo.CMS.Custom.Swagger
+namespace UmbracoDemo.CMS.Custom.Swagger;
+
+public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter
 {
-    public class DeliveryApiContentTypesSchemaFilter : ISchemaFilter
+    private readonly IOptions<SwaggerGenOptions> _swaggerGenOptions;
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
+    private readonly ISchemaIdSelector _schemaIdSelector;
+    private readonly IShortStringHelper _shortStringHelper;
+
+    public DeliveryApiContentTypesSchemaFilter(IOptions<SwaggerGenOptions> swaggerGenOptions, IContentTypeService contentTypeService, IPublishedContentTypeFactory publishedContentTypeFactory, ISchemaIdSelector schemaIdSelector, IShortStringHelper shortStringHelper)
     {
-        private readonly IOptions<SwaggerGenOptions> _swaggerGenOptions;
-        private readonly IContentTypeService _contentTypeService;
-        private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
-        private readonly ISchemaIdSelector _schemaIdSelector;
-        private readonly IShortStringHelper _shortStringHelper;
+        _swaggerGenOptions = swaggerGenOptions;
+        _contentTypeService = contentTypeService;
+        _publishedContentTypeFactory = publishedContentTypeFactory;
+        _schemaIdSelector = schemaIdSelector;
+        _shortStringHelper = shortStringHelper;
+    }
 
-        public DeliveryApiContentTypesSchemaFilter(IOptions<SwaggerGenOptions> swaggerGenOptions, IContentTypeService contentTypeService, IPublishedContentTypeFactory publishedContentTypeFactory, ISchemaIdSelector schemaIdSelector, IShortStringHelper shortStringHelper)
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        FixEnums(schema, context);
+
+        // Orval/Swashbuckle compatible, NOT supported by NSwag
+        bool useOneOfForPolymorphism = _swaggerGenOptions.Value.SchemaGeneratorOptions.UseOneOfForPolymorphism;
+
+        if (!useOneOfForPolymorphism && !_swaggerGenOptions.Value.SchemaGeneratorOptions.UseAllOfForInheritance)
         {
-            _swaggerGenOptions = swaggerGenOptions;
-            _contentTypeService = contentTypeService;
-            _publishedContentTypeFactory = publishedContentTypeFactory;
-            _schemaIdSelector = schemaIdSelector;
-            _shortStringHelper = shortStringHelper;
+            return;
         }
 
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        if (typeof(IApiElement) == context.Type)
         {
-            FixEnums(schema, context);
-
-            // Orval/Swashbuckle compatible, NOT supported by NSwag
-            bool useOneOfForPolymorphism = _swaggerGenOptions.Value.SchemaGeneratorOptions.UseOneOfForPolymorphism;
-
-            if (!useOneOfForPolymorphism && !_swaggerGenOptions.Value.SchemaGeneratorOptions.UseAllOfForInheritance)
-            {
-                return;
-            }
-
-            if (typeof(IApiElement) == context.Type)
-            {
-                HandleIApiElement(schema, context, useOneOfForPolymorphism);
-                return;
-            }
-
-            if (typeof(IApiContentResponse) == context.Type)
-            {
-                HandleIApiContentResponse(schema, context, useOneOfForPolymorphism);
-                return;
-            }
+            HandleIApiElement(schema, context, useOneOfForPolymorphism);
+            return;
         }
 
-        private void HandleIApiElement(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
+        if (typeof(IApiContent) == context.Type)
         {
-            OpenApiSchema? originalSchema = null;
-            if (useOneOfForPolymorphism)
-            {
-                // Swashbuckle doesn't allow us to return an inline schema
-                // So we instead clone the current schema as IApiElementBase and update the current schema to be OneOf
+            HandleIApiContent(schema, context, useOneOfForPolymorphism);
+            return;
+        }
 
-                originalSchema = schema;
-                schema = new OpenApiSchema(originalSchema);
+        if (typeof(IApiContentResponse) == context.Type)
+        {
+            HandleIApiContentResponse(schema, context, useOneOfForPolymorphism);
+            return;
+        }
+    }
 
-                context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiElement>(true), schema);
+    private void HandleIApiElement(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
+    {
+        OpenApiSchema? originalSchema = null;
+        if (useOneOfForPolymorphism)
+        {
+            // Swashbuckle doesn't allow us to return an inline schema
+            // So we instead clone the current schema as IApiElementBase and update the current schema to be OneOf
 
-                ClearSchema(originalSchema);
-            }
+            originalSchema = schema;
+            schema = new OpenApiSchema(originalSchema);
 
-            schema.Discriminator = new OpenApiDiscriminator
-            {
-                PropertyName = "contentType"
-            };
+            context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiElement>(true), schema);
 
-            foreach (IContentType contentType in _contentTypeService.GetAll())
-            {
-                IPublishedContentType publishedContentType = _publishedContentTypeFactory.CreateContentType(contentType);
+            ClearSchema(originalSchema);
+        }
 
-                var contentTypeSchema = context.SchemaRepository.AddDefinition(
-                    $"{GetContentTypeSchemaId(contentType)}ContentModel",
-                    new OpenApiSchema
+        schema.Discriminator = new OpenApiDiscriminator
+        {
+            PropertyName = "contentType"
+        };
+
+        foreach (IContentType contentType in _contentTypeService.GetAll())
+        {
+            IPublishedContentType publishedContentType = _publishedContentTypeFactory.CreateContentType(contentType);
+
+            var contentTypeSchema = context.SchemaRepository.AddDefinition(
+                $"{GetContentTypeSchemaId(contentType)}ElementModel",
+                new OpenApiSchema
+                {
+                    Type = "object",
+                    AllOf = { new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiElement>(useOneOfForPolymorphism) } } },
+                    AdditionalPropertiesAllowed = false,
+                    Properties =
                     {
-                        Type = "object",
-                        AllOf = { new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiElement>(useOneOfForPolymorphism) } } },
-                        AdditionalPropertiesAllowed = false,
-                        Properties =
-                        {
-                                ["properties"] = context.SchemaRepository.AddDefinition(
-                                    $"{GetContentTypeSchemaId(contentType)}PropertiesModel",
-                                    new OpenApiSchema
-                                    {
-                                        Type = "object",
-                                        AdditionalPropertiesAllowed = true,
-                                        AllOf = contentType.ContentTypeComposition.Select(c => new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(c)}PropertiesModel" } }).ToList(),
-                                        Properties = publishedContentType.PropertyTypes
-                                            .Where(p => contentType.PropertyTypes.Any(x => x.Alias == p.Alias)) // Filter out composition properties
-                                            .ToDictionary(
-                                                p => p.Alias,
-                                                p =>
-                                                {
-                                                    OpenApiSchema propertySchema = context.SchemaGenerator.GenerateSchema(GetPropertyType(p), context.SchemaRepository);
-                                                    propertySchema.Nullable = true;
-
-                                                    return propertySchema;
-                                                })
-                                    }
-                                )
-                        }
-                    }
-                );
-
-                schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
-                originalSchema?.OneOf.Add(contentTypeSchema);
-            }
-        }
-
-        private void HandleIApiContentResponse(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
-        {
-            // Ensure IApiElement is generated if not already
-            context.SchemaGenerator.GenerateSchema(typeof(IApiElement), context.SchemaRepository);
-
-            OpenApiSchema? originalSchema = null;
-            if (useOneOfForPolymorphism)
-            {
-                originalSchema = schema;
-                schema = new OpenApiSchema(originalSchema);
-                context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiContentResponse>(true), schema);
-
-                ClearSchema(originalSchema);
-            }
-
-            schema.AllOf.Add(new OpenApiSchema
-            {
-                Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiElement>(useOneOfForPolymorphism) }
-            });
-            schema.Discriminator = new OpenApiDiscriminator
-            {
-                PropertyName = "contentType"
-            };
-
-            foreach (IContentType contentType in _contentTypeService.GetAll().Where(c => !c.IsElement))
-            {
-                var contentTypeSchema = context.SchemaRepository.AddDefinition(
-                    $"{GetContentTypeSchemaId(contentType)}ContentResponseModel",
-                    new OpenApiSchema
-                    {
-                        Type = "object",
-                        AdditionalPropertiesAllowed = false,
-                        AllOf =
-                        {
+                        ["properties"] = context.SchemaRepository.AddDefinition(
+                            $"{GetContentTypeSchemaId(contentType)}PropertiesModel",
                             new OpenApiSchema
                             {
-                                Reference = new OpenApiReference
-                                {
-                                    Type = ReferenceType.Schema,
-                                    Id = GetTypeSchemaId<IApiContentResponse>(useOneOfForPolymorphism)
-                                }
-                            },
-                            new OpenApiSchema
-                            {
-                                Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(contentType)}ContentModel" }
+                                Type = "object",
+                                AdditionalPropertiesAllowed = true,
+                                AllOf = contentType.ContentTypeComposition.Select(c => new OpenApiSchema { Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(c)}PropertiesModel" } }).ToList(),
+                                Properties = publishedContentType.PropertyTypes
+                                    .Where(p => contentType.PropertyTypes.Any(x => x.Alias == p.Alias)) // Filter out composition properties
+                                    .ToDictionary(
+                                        p => p.Alias,
+                                        p =>
+                                        {
+                                            OpenApiSchema propertySchema = context.SchemaGenerator.GenerateSchema(GetPropertyType(p), context.SchemaRepository);
+                                            propertySchema.Nullable = true;
+                                            return propertySchema;
+                                        }
+                                    )
                             }
+                        )
+                    }
+                }
+            );
+
+            schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
+            originalSchema?.OneOf.Add(contentTypeSchema);
+        }
+    }
+
+    private void HandleIApiContent(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
+    {
+        // Ensure IApiElement is generated if not already
+        context.SchemaGenerator.GenerateSchema(typeof(IApiElement), context.SchemaRepository);
+
+        OpenApiSchema? originalSchema = null;
+        if (useOneOfForPolymorphism)
+        {
+            originalSchema = schema;
+            schema = new OpenApiSchema(originalSchema);
+            context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiContent>(true), schema);
+
+            ClearSchema(originalSchema);
+        }
+
+        schema.AllOf.Add(new OpenApiSchema
+        {
+            Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiElement>(useOneOfForPolymorphism) }
+        });
+        schema.Discriminator = new OpenApiDiscriminator
+        {
+            PropertyName = "contentType"
+        };
+
+        foreach (IContentType contentType in _contentTypeService.GetAll().Where(c => !c.IsElement))
+        {
+            var contentTypeSchema = context.SchemaRepository.AddDefinition(
+                $"{GetContentTypeSchemaId(contentType)}ContentModel",
+                new OpenApiSchema
+                {
+                    Type = "object",
+                    AdditionalPropertiesAllowed = false,
+                    AllOf =
+                    {
+                        new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = GetTypeSchemaId<IApiContent>(useOneOfForPolymorphism)
+                            }
+                        },
+                        new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(contentType)}ElementModel" }
                         }
                     }
-                );
+                }
+            );
 
-                schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
-                originalSchema?.OneOf.Add(contentTypeSchema);
-            }
+            schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
+            originalSchema?.OneOf.Add(contentTypeSchema);
         }
+    }
 
-        private string GetContentTypeSchemaId(IContentTypeBase contentType)
+    private void HandleIApiContentResponse(OpenApiSchema schema, SchemaFilterContext context, bool useOneOfForPolymorphism)
+    {
+        // Ensure IApiContent is generated if not already
+        context.SchemaGenerator.GenerateSchema(typeof(IApiContent), context.SchemaRepository);
+
+        OpenApiSchema? originalSchema = null;
+        if (useOneOfForPolymorphism)
         {
-            // This is what ModelsBuilder currently also uses
-            return contentType.Alias.ToCleanString(_shortStringHelper, CleanStringType.ConvertCase | CleanStringType.PascalCase);
+            originalSchema = schema;
+            schema = new OpenApiSchema(originalSchema);
+            context.SchemaRepository.Schemas.Add(GetTypeSchemaId<IApiContentResponse>(true), schema);
+
+            ClearSchema(originalSchema);
         }
 
-        private string GetTypeSchemaId<T>(bool baseSuffix)
+        schema.AllOf.Add(new OpenApiSchema
         {
-            return _schemaIdSelector.SchemaId(typeof(T)) + (baseSuffix ? "Base" : null);
-        }
-
-        private void ClearSchema(OpenApiSchema schema)
+            Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = GetTypeSchemaId<IApiContent>(useOneOfForPolymorphism) }
+        });
+        schema.Discriminator = new OpenApiDiscriminator
         {
-            schema.AllOf.Clear();
-            schema.OneOf.Clear();
-            schema.AnyOf.Clear();
-            schema.Required.Clear();
-            schema.Properties.Clear();
-            schema.AdditionalProperties = null;
-            schema.Discriminator = null;
-        }
+            PropertyName = "contentType"
+        };
 
-        // HACK: The DeliveryApi property value type is currently not exposed by Umbraco
-        private static readonly FieldInfo? ConverterField = typeof(PublishedPropertyType).GetField("_converter", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-        private static Type GetPropertyType(IPublishedPropertyType publishedPropertyType)
+        foreach (IContentType contentType in _contentTypeService.GetAll().Where(c => !c.IsElement))
         {
-            Type modelClrType = publishedPropertyType.ModelClrType;
+            var contentTypeSchema = context.SchemaRepository.AddDefinition(
+                $"{GetContentTypeSchemaId(contentType)}ContentResponseModel",
+                new OpenApiSchema
+                {
+                    Type = "object",
+                    AdditionalPropertiesAllowed = false,
+                    AllOf =
+                    {
+                        new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = GetTypeSchemaId<IApiContentResponse>(useOneOfForPolymorphism)
+                            }
+                        },
+                        new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = $"{GetContentTypeSchemaId(contentType)}ContentModel" }
+                        }
+                    }
+                }
+            );
 
-            switch (ConverterField?.GetValue(publishedPropertyType))
-            {
-                case BlockListPropertyValueConverter:
-                    // HACK: Needed due to umbraco returning the wrong type
-                    // https://github.com/umbraco/Umbraco-CMS/pull/14728
-                    return typeof(ApiBlockListModel);
-                case IDeliveryApiPropertyValueConverter propertyValueConverter:
-                    return propertyValueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType);
-                default:
-                    return modelClrType;
-            }
+            schema.Discriminator.Mapping[contentType.Alias] = contentTypeSchema.Reference.ReferenceV3;
+            originalSchema?.OneOf.Add(contentTypeSchema);
         }
+    }
 
-        // HACK: Needed because Umbraco generates invalid enum schemas
-        // https://github.com/umbraco/Umbraco-CMS/pull/14727
-        private static void FixEnums(OpenApiSchema schema, SchemaFilterContext context)
+    private string GetContentTypeSchemaId(IContentTypeBase contentType)
+    {
+        // This is what ModelsBuilder currently also uses
+        return contentType.Alias.ToCleanString(_shortStringHelper, CleanStringType.ConvertCase | CleanStringType.PascalCase);
+    }
+
+    private string GetTypeSchemaId<T>(bool baseSuffix)
+    {
+        return _schemaIdSelector.SchemaId(typeof(T)) + (baseSuffix ? "Base" : null);
+    }
+
+    private void ClearSchema(OpenApiSchema schema)
+    {
+        schema.AllOf.Clear();
+        schema.OneOf.Clear();
+        schema.AnyOf.Clear();
+        schema.Required.Clear();
+        schema.Properties.Clear();
+        schema.AdditionalProperties = null;
+        schema.Discriminator = null;
+    }
+
+    // HACK: The DeliveryApi property value type is currently not exposed by Umbraco
+    private static readonly FieldInfo? ConverterField = typeof(PublishedPropertyType).GetField("_converter", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+    private static Type GetPropertyType(IPublishedPropertyType publishedPropertyType)
+    {
+        Type modelClrType = publishedPropertyType.ModelClrType;
+
+        switch (ConverterField?.GetValue(publishedPropertyType))
         {
-            if (!context.Type.IsEnum) return;
-
-            schema.Type = "string";
-            schema.Format = null;
+            case BlockListPropertyValueConverter:
+                // HACK: Needed due to umbraco returning the wrong type
+                // https://github.com/umbraco/Umbraco-CMS/pull/14728
+                return typeof(ApiBlockListModel);
+            case IDeliveryApiPropertyValueConverter propertyValueConverter:
+                return propertyValueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType);
+            default:
+                return modelClrType;
         }
+    }
+
+    // HACK: Needed because Umbraco generates invalid enum schemas
+    // https://github.com/umbraco/Umbraco-CMS/pull/14727
+    private static void FixEnums(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (!context.Type.IsEnum) return;
+
+        schema.Type = "string";
+        schema.Format = null;
     }
 }

--- a/src/UmbracoDemo.CMS/Custom/Swagger/DeliveryApiContentTypesSchemaFilter.cs
+++ b/src/UmbracoDemo.CMS/Custom/Swagger/DeliveryApiContentTypesSchemaFilter.cs
@@ -100,8 +100,13 @@ namespace UmbracoDemo.CMS.Custom.Swagger
                                             .Where(p => contentType.PropertyTypes.Any(x => x.Alias == p.Alias)) // Filter out composition properties
                                             .ToDictionary(
                                                 p => p.Alias,
-                                                p => context.SchemaGenerator.GenerateSchema(GetPropertyType(p), context.SchemaRepository)
-                                            )
+                                                p =>
+                                                {
+                                                    OpenApiSchema propertySchema = context.SchemaGenerator.GenerateSchema(GetPropertyType(p), context.SchemaRepository);
+                                                    propertySchema.Nullable = true;
+
+                                                    return propertySchema;
+                                                })
                                     }
                                 )
                         }

--- a/src/UmbracoDemo.CMS/Startup.cs
+++ b/src/UmbracoDemo.CMS/Startup.cs
@@ -55,11 +55,13 @@ public class Startup
         // Enable generation of typed content responses based on CMS content types
         services.Configure<SwaggerGenOptions>(options =>
         {
+            options.SupportNonNullableReferenceTypes();
+
             // UseOneOfForPolymorphism is disabled as we are consuming the swagger with NSwag
             // If using other code generations tools, like Orval, it should be enabled for better compatibility
+            //options.UseOneOfForPolymorphism();
 
-            //options.SchemaGeneratorOptions.UseOneOfForPolymorphism = true;
-            options.SchemaGeneratorOptions.UseAllOfForInheritance = true;
+            options.UseAllOfForInheritance();
 
             options.SchemaFilter<DeliveryApiContentTypesSchemaFilter>();
         });

--- a/src/UmbracoDemo.CMS/Startup.cs
+++ b/src/UmbracoDemo.CMS/Startup.cs
@@ -1,3 +1,4 @@
+using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Core;
 using UmbracoDemo.CMS.Custom.Swagger;
@@ -49,6 +50,18 @@ public class Startup
         services.AddControllers().AddJsonOptions(Constants.JsonOptionsNames.DeliveryApi, options =>
         {
             options.JsonSerializerOptions.TypeInfoResolver = new CustomDeliveryApiJsonTypeResolver();
+        });
+
+        // Enable generation of typed content responses based on CMS content types
+        services.Configure<SwaggerGenOptions>(options =>
+        {
+            // UseOneOfForPolymorphism is disabled as we are consuming the swagger with NSwag
+            // If using other code generations tools, like Orval, it should be enabled for better compatibility
+
+            //options.SchemaGeneratorOptions.UseOneOfForPolymorphism = true;
+            options.SchemaGeneratorOptions.UseAllOfForInheritance = true;
+
+            options.SchemaFilter<DeliveryApiContentTypesSchemaFilter>();
         });
     }
 

--- a/src/UmbracoDemo.CMS/UmbracoDemo.CMS.csproj
+++ b/src/UmbracoDemo.CMS/UmbracoDemo.CMS.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.6" />
     <PackageReference Include="Umbraco.Cms" Version="12.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Generated client will now have proper typed responses.
The client code still needs to be updated to take advantage of this instead of using reflection.